### PR TITLE
feat: Implement content catalog API and database seeding.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "docker:dev": "scripts\\dev.bat",
     "docker:prod": "scripts\\prod.bat",
     "docker:clean": "scripts\\clean.bat",
-    "docker:logs": "docker-compose logs -f"
+    "docker:logs": "docker-compose logs -f",
+    "db:seed": "ts-node src/database/seed.ts"
   },
   "keywords": [
     "api",

--- a/src/controllers/packageController.ts
+++ b/src/controllers/packageController.ts
@@ -1,0 +1,22 @@
+import {Request, Response, NextFunction} from 'express';
+import * as packageService from '../services/packageService';
+
+export const getAllPackages = async (req:Request,res:Response,next:NextFunction) => {
+    try {
+        const packages = await packageService.getAllPackages();
+        res.status(200).json(packages);
+    } catch (error) {
+        next(error);
+    }
+}
+
+export const getPackageById = async (req:Request,res:Response,next:NextFunction) => {
+    try {
+        const packageId = parseInt(req.params.id);
+        const tvPackage = await packageService.getPackageById(packageId);
+        res.status(200).json(tvPackage);
+    } catch (error) {
+        next(error);
+    }
+}
+

--- a/src/database/seed.ts
+++ b/src/database/seed.ts
@@ -1,0 +1,106 @@
+import { sequelize } from './connection';
+import { Package } from '../models/Package';
+import Channel from '../models/Channel';
+import '../models';
+
+// Sample data for seeding
+const packagesData = [
+  {
+    name: 'Cosmic Comedy Central',
+    description:
+      'A package full of laughter from across the galaxies. Includes sitcoms from Dimension C-137.',
+    price: 9.99,
+  },
+  {
+    name: 'Multiverse Mystery Mix',
+    description:
+      'For the detectives at heart. Unravel mysteries from alternate timelines and realities.',
+    price: 12.99,
+  },
+  {
+    name: 'Interdimensional Sports League',
+    description:
+      'Catch live Blernsball games and the annual Gazorpazorpfield wrestling championship.',
+    price: 15.99,
+  },
+];
+
+const channelsData = [
+  // Comedy Channels
+  {
+    name: 'Giggle Galaxy TV',
+    description: '24/7 stand-up from humanoid and non-humanoid comedians.',
+    dimension_origin: 'Dimension C-137',
+  },
+  {
+    name: 'The Prankverse',
+    description:
+      'Hidden camera shows featuring elaborate interdimensional pranks.',
+    dimension_origin: 'Dimension 42-J',
+  },
+
+  // Mystery Channels
+  {
+    name: 'Noir Nebula Network',
+    description:
+      'Classic black and white detective stories from a rain-soaked reality.',
+    dimension_origin: 'Dimension Noir-7',
+  },
+  {
+    name: 'Clue Continuum',
+    description:
+      'Interactive mystery channel where viewers vote on the next clue.',
+    dimension_origin: 'Dimension ?-?',
+  },
+
+  // Sports Channels
+  {
+    name: 'Blernsball Bonanza',
+    description: 'The official home of the Universal Blernsball Association.',
+    dimension_origin: 'Dimension B-Ball',
+  },
+  {
+    name: 'Arena of the Gods',
+    description:
+      'Mythological figures competing in epic, world-altering sporting events.',
+    dimension_origin: 'Olympus-Prime',
+  },
+];
+const seedDatabase = async () => {
+  try {
+    // Manually drop tables in the correct order to avoid foreign key constraints
+    await sequelize.query('SET FOREIGN_KEY_CHECKS = 0;');
+    await sequelize.sync({ force: true });
+    await sequelize.query('SET FOREIGN_KEY_CHECKS = 1;');
+
+    console.log('Database synchronized. Tables dropped and recreated.');
+
+    // Create Packages
+    const createdPackages = await Package.bulkCreate(packagesData);
+    console.log(`Created ${createdPackages.length} packages.`);
+
+    // Create Channels
+    const createdChannels = await Channel.bulkCreate(channelsData);
+    console.log(`Created ${createdChannels.length} channels.`);
+
+    // Associate Channels with Packages
+    // We use a Promise.all to run these associations in parallel for better performance
+    await Promise.all([
+      createdPackages[0].addChannels([createdChannels[0], createdChannels[1]]), // Comedy
+      createdPackages[1].addChannels([createdChannels[2], createdChannels[3]]), // Mystery
+      createdPackages[2].addChannels([createdChannels[4], createdChannels[5]]), // Sports
+    ]);
+
+    console.log('Channels associated with packages.');
+
+    console.log('✅ Seeding completed successfully!');
+  } catch (error) {
+    console.error('Error during database seeding:', error);
+  } finally {
+    await sequelize.close();
+    console.log('Database connection closed.');
+  }
+};
+
+seedDatabase();
+

--- a/src/models/Package.ts
+++ b/src/models/Package.ts
@@ -1,34 +1,60 @@
-import { DataTypes, Model } from 'sequelize';
+import {
+  Model,
+  DataTypes,
+  Optional,
+  BelongsToManyAddAssociationsMixin, // Correct type for adding multiple associations
+  BelongsToManyGetAssociationsMixin,
+} from 'sequelize';
 import { sequelize } from '../database/connection';
+import Channel from './Channel';
 
-interface PackageAttributes {
-  id?: number;
+// Interface for Package attributes
+export interface PackageAttributes {
+  id: number;
   name: string;
   description: string;
   price: number;
 }
 
-class Package extends Model<PackageAttributes> implements PackageAttributes {
+// Interface for Package creation attributes (id is optional)
+interface PackageCreationAttributes extends Optional<PackageAttributes, 'id'> {}
+
+// Sequelize Model for Package
+export class Package
+  extends Model<PackageAttributes, PackageCreationAttributes>
+  implements PackageAttributes
+{
   public id!: number;
   public name!: string;
   public description!: string;
   public price!: number;
+  //TODO: We will delete the timeStamps in the future if we don't need them
+  // Timestamps
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+
+  // --- Association methods ---
+  // These are injected by Sequelize after associations are defined.
+  // We declare them here to make TypeScript aware of them.
+  public addChannels!: BelongsToManyAddAssociationsMixin<Channel, number>; // Use plural form here
+  public getChannels!: BelongsToManyGetAssociationsMixin<Channel>;
 }
 
+// Initialize Package model
 Package.init(
   {
     id: {
-      type: DataTypes.INTEGER,
+      type: DataTypes.INTEGER.UNSIGNED,
       autoIncrement: true,
       primaryKey: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: new DataTypes.STRING(128),
       allowNull: false,
     },
     description: {
       type: DataTypes.TEXT,
-      allowNull: true,
+      allowNull: false,
     },
     price: {
       type: DataTypes.DECIMAL(10, 2),
@@ -36,10 +62,8 @@ Package.init(
     },
   },
   {
-    sequelize,
-    modelName: 'Package',
-    timestamps: false,
+    tableName: 'packages',
+    sequelize, // We need to pass the connection instance
   }
 );
 
-export default Package;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,5 +1,5 @@
 import {User} from './User';
-import Package from './Package';
+import {Package} from './Package';
 import Channel from './Channel';
 import Subscription from './Subscription';
 import Translation from './Translation';

--- a/src/routes/packageRoutes.ts
+++ b/src/routes/packageRoutes.ts
@@ -1,0 +1,9 @@
+import {Router} from 'express';
+import { getAllPackages, getPackageById } from '../controllers/packageController';
+
+const router = Router();
+
+router.get('/', getAllPackages);
+router.get('/:id', getPackageById);
+
+export default router;

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -1,8 +1,11 @@
 import authRoutes from "./authRoutes";
+import packageRoutes from "./packageRoutes";
+
 import Router from "express";
 
 const router = Router();
 
 router.use('/auth', authRoutes);
+router.use('/packages', packageRoutes);
 
 export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,10 +19,8 @@ async function startServer() {
     //...Middlewares...
     app.use(express.json());
     app.use(cookieParser());
-
-    //...Routes...
     app.use("/api/v1", router);
-  
+
     app.listen(PORT, () => console.log(`🚀 Server running on port ${PORT}`));
   } catch (error) {
     console.error("❌ Unable to start the server:", error);

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -2,7 +2,11 @@ import bcrypt from "bcrypt";
 import { User } from "../models";
 import type { UserAttributes } from "../models/User";
 import { generateAuthTokens } from "../utils/jwt";
-import { ConflictError, NotFoundError, UnauthorizedError } from "../utils/errors";
+import {
+  ConflictError,
+  NotFoundError,
+  UnauthorizedError,
+} from "../utils/errors";
 
 export const registerUser = async (userData: Omit<UserAttributes, "id">) => {
   const { username, email, password_hash, preferred_language } = userData;
@@ -29,20 +33,22 @@ export const registerUser = async (userData: Omit<UserAttributes, "id">) => {
   };
 };
 
-export const loginUser = async (credentials: Pick<UserAttributes, 'email' | 'password_hash'>) => {
-    const { email, password_hash: password } = credentials;
+export const loginUser = async (
+  credentials: Pick<UserAttributes, "email" | "password_hash">
+) => {
+  const { email, password_hash: password } = credentials;
 
-    const user = await User.findByEmail(email);
-    if (!user) {
-        throw new NotFoundError('User not found.');
-    }
+  const user = await User.findByEmail(email);
+  if (!user) {
+    throw new NotFoundError("User not found.");
+  }
 
-    const isMatch = await user.comparePassword(password);
-    if (!isMatch) {
-        throw new UnauthorizedError('Invalid credentials.');
-    }
+  const isMatch = await user.comparePassword(password);
+  if (!isMatch) {
+    throw new UnauthorizedError("Invalid credentials.");
+  }
 
-    const tokens = generateAuthTokens(user);
+  const tokens = generateAuthTokens(user);
 
-    return tokens;
+  return tokens;
 };

--- a/src/services/packageService.ts
+++ b/src/services/packageService.ts
@@ -1,0 +1,21 @@
+import {Package} from '../models/Package';
+import Channel from '../models/Channel';
+import {NotFoundError} from '../utils/errors';
+
+export const getAllPackages = async ():Promise<Package[]> =>{
+    return Package.findAll();
+}
+
+export const getPackageById = async (packageId:number): Promise<Package> => {
+    const tvPackage = await Package.findByPk(packageId,{
+        include:{
+            model: Channel,
+            as: 'channels',
+            through: {attributes: []},
+        }
+    });
+    if (!tvPackage) {
+        throw new NotFoundError(`Package with id ${packageId} not found`);
+    }
+    return tvPackage;
+}


### PR DESCRIPTION
- Adds a 'db:seed' script to populate the database with sample packages and channels.
- Creates public API endpoints to get all packages (GET /packages) and a single package by ID (GET /packages/:id).
- The endpoint for a single package includes its associated channels.
- Follows the established layered architecture (Controller, Service).