### PR TITLE
feat(worker): Persist translations to database

### DIFF
--- a/src/jobs/translationProcessor.ts
+++ b/src/jobs/translationProcessor.ts
@@ -1,0 +1,65 @@
+import { Job } from 'bullmq';
+import { Translation } from '../models/Translation';
+
+// Interface for the job data
+interface TranslationJobData {
+  packageId: number;
+  languageCode: string;
+  originalName: string;
+  originalDescription: string;
+}
+
+/**
+ * Simulates a call to an external translation API.
+ * @param text - The text to translate.
+ * @param lang - The language code.
+ * @returns The "translated" text.
+ */
+const mockTranslateAPI = (text: string, lang: string): string => {
+  // In a real app, you would call a service like Google Translate here.
+  // We'll just append the language code for a cleaner simulation.
+  console.log(`   - Simulating translation of "${text}" to ${lang}...`);
+  return `${text}`;
+};
+
+/**
+ * Processes a translation job: it "translates" and saves it to the database.
+ * @param job - The BullMQ job object.
+ */
+export const processTranslationJob = async (job: Job<TranslationJobData>) => {
+  const { packageId, languageCode, originalName, originalDescription } =
+    job.data;
+
+  // 1. Simulate the call to the translation API
+  const translatedName = mockTranslateAPI(originalName, languageCode);
+  const translatedDescription = mockTranslateAPI(
+    originalDescription,
+    languageCode
+  );
+
+  // 2. Save the result in the database.
+  const [translation, created] = await Translation.findOrCreate({
+    where: {
+      itemType: 'package',
+      itemId: packageId,
+      languageCode: languageCode,
+    },
+    defaults: {
+      itemType: 'package',
+      itemId: packageId,
+      languageCode: languageCode,
+      translatedName,
+      translatedDescription,
+    },
+  });
+
+  if (created) {
+    console.log(
+      `   - Translation saved in the database with ID: ${translation.id}`
+    );
+  } else {
+    console.log(
+      `   - The translation already existed in the database. No new entry was created.`
+    );
+  }
+};

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,33 +1,41 @@
 import { Worker } from "bullmq";
 import { redisConnection } from "./config/reddis/reddis";
+import { connectToDatabase } from "./config/database/connection";
+import { processTranslationJob } from "./jobs/translationProcessor";
 
-const TRANSLATION_QUEUE_NAME = "translations_queue";
+const TRANSLATION_QUEUE_NAME = 'translations_queue';
 
-console.log("🔶 The OmniverseTV worker has started.");
-console.log(
-  "Waiting for translation jobs in the " + TRANSLATION_QUEUE_NAME + ""
-);
+/**
+ * Initialize the worker 
+ */
+const startWorker = async()=>{
+  try{
+    //Connect to the database
+    await connectToDatabase();
+    console.log('✅ [WORKER] Connected to the database');
 
-//Create a new woeker instance
-const worker = new Worker(TRANSLATION_QUEUE_NAME, async (job) => {
-  // This is where the translation logic will eventually go.
-  // For now, we simulate the work to confirm the system works.
-  console.log("🔵[WORKER] Processing job: " + job.id);
-  console.log(`...-Received job data: ${JSON.stringify(job.data)}`);
+    console.log('🔶 OmniverseTV worker started.');
+    console.log(
+      `Listening for jobs in queue:  "${TRANSLATION_QUEUE_NAME}"...`
+    );
 
-  //Simulate a time-consuming task, like calling an external translation API
-  await new Promise((resolve) => setTimeout(resolve, 3000));
+    //Create the worker instance
+    new Worker(
+      TRANSLATION_QUEUE_NAME,
+      async(job) => {
+        console.log(`\n🔵 [WORKER] Processing translation job #${job.id}`);
+        console.log(`   - Data received: ${JSON.stringify(job.data)}`);
 
-  // In a real implementation, we would save the translation to the database here.
-  const mockTranslation =`Content translated for package ${job.data.packageId} and language ${job.data.languageCode}`;
-  console.log(`🟢[WORKER] Job completed: #${job.id}`);
-  //Mark the job as completed
-  return{status: 'completed', result: mockTranslation}},
-  //Connection to the Redis server
-  {connection: redisConnection}
-);
+        //Call the separated processor login
+        await processTranslationJob(job);
 
-worker.on('failed', (job, err) => {
-  console.log(`🔴[WORKER] Worker failed to process job #${job?.id}. Error: ${err.message}`);
-  console.log(err);
-});
+        console.log(`🟢 [WORKER] Job #${job.id} completed successfully.`);
+      },{connection: redisConnection}
+    );
+  } catch(error){
+    console.error('🔴 [WORKER] Error al iniciar el worker:', error);
+    process.exit(1);
+  }
+};
+
+startWorker();


### PR DESCRIPTION
- The translation worker now saves the processed translation job to the 'Translations' table.
- Uses 'findOrCreate' for robustness against duplicate jobs.
- Refactors the API response for translated packages to be cleaner and more frontend-friendly.