### PR TITLE
feat: Integrate real translation API and add robust error handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,14 @@ services:
       - REDIS_PORT=6379
       - JWT_ACCESS_SECRET=${JWT_ACCESS_SECRET}
       - JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET}
+      - DEEPL_API_KEY=${DEEPL_API_KEY}
     depends_on:
       database:
         condition: service_healthy
       cache:
         condition: service_started
+    dns:
+      - 8.8.8.8
     networks:
       - omniverse-net
 
@@ -27,6 +30,8 @@ services:
         condition: service_healthy
       cache:
         condition: service_started
+    dns:
+      - 8.8.8.8
     networks:
       - omniverse-net
 
@@ -70,3 +75,4 @@ networks:
 volumes:
   db_data:
   cache_data:
+

--- a/src/jobs/translationProcessor.ts
+++ b/src/jobs/translationProcessor.ts
@@ -1,27 +1,15 @@
 import { Job } from 'bullmq';
 import { Translation } from '../models/Translation';
+import { fetchTranslation } from '../utils/translator';
 
 // Interface for the job data
 interface TranslationJobData {
-  itemType: 'package' | "channel";
+  itemType: 'package' | 'channel';
   itemId: number;
   languageCode: string;
   originalName: string;
   originalDescription: string;
 }
-
-/**
- * Simulates a call to an external translation API.
- * @param text - The text to translate.
- * @param lang - The language code.
- * @returns The "translated" text.
- */
-const mockTranslateAPI = (text: string, lang: string): string => {
-  // In a real app, you would call a service like Google Translate here.
-  // We'll just append the language code for a cleaner simulation.
-  console.log(`   - Simulating translation of "${text}" to ${lang}...`);
-  return `${text}`;
-};
 
 /**
  * Processes a translation job: it "translates" and saves it to the database.
@@ -31,37 +19,50 @@ export const processTranslationJob = async (job: Job<TranslationJobData>) => {
   const { itemType, itemId, languageCode, originalName, originalDescription } =
     job.data;
 
-  // 1. Simulate the call to the translation API.
-  const translatedName = mockTranslateAPI(originalName, languageCode);
-  const translatedDescription = mockTranslateAPI(
-    originalDescription,
-    languageCode
+  console.log(
+    `-------> Starting translation for ${itemType} #${itemId} to ${languageCode.toUpperCase()}...`
   );
 
-  // 2. Save the result in the database.
-  // This logic now works for any itemType passed in the job data.
-  const [translation, created] = await Translation.findOrCreate({
-    where: {
-      itemType,
-      itemId,
-      languageCode,
-    },
-    defaults: {
-      itemType,
-      itemId,
-      languageCode,
-      translatedName,
-      translatedDescription,
-    },
-  });
+  try {
+    // 1. Call the translation utility for both texts.
+    // We use Promise.all to run both API calls in parallel.
+    const [translatedName, translatedDescription] = await Promise.all([
+      fetchTranslation(originalName, languageCode),
+      fetchTranslation(originalDescription, languageCode),
+    ]);
 
-  if (created) {
-    console.log(
-      `   - Translation for ${itemType} #${itemId} saved with ID: ${translation.id}`
+    // 2. Save the result in the database.
+    const [translation, created] = await Translation.findOrCreate({
+      where: {
+        itemType,
+        itemId,
+        languageCode,
+      },
+      defaults: {
+        itemType,
+        itemId,
+        languageCode,
+        translatedName,
+        translatedDescription,
+      },
+    });
+
+    if (created) {
+      console.log(
+        `-------> Translation for ${itemType} #${itemId} saved with ID: ${translation.id}`
+      );
+    } else {
+      console.log(
+        `-------> Translation for ${itemType} #${itemId} already existed.`
+      );
+    }
+  } catch (error: any) {
+    // This block will catch any error thrown from fetchTranslation.
+    console.error(
+      `🔴 [PROCESSOR] Failed to process translation job #${job.id}. Reason: ${error.message}`
     );
-  } else {
-    console.log(
-      `   - Translation for ${itemType} #${itemId} already existed. No new entry created.`
-    );
+    // By re-throwing the error, we ensure the BullMQ job is marked as failed.
+    throw error;
   }
 };
+

--- a/src/services/channelService.ts
+++ b/src/services/channelService.ts
@@ -3,6 +3,7 @@ import { Translation } from '../models/Translation';
 import { NotFoundError } from '../utils/errors';
 import { translationQueue } from '../queues/translationQueue';
 import { redisClient } from '../config/reddis/reddisClient';
+import { getPendingMessage } from '../utils/localization';
 
 // Defines the shape of the API response for a channel.
 interface TranslatedChannelResponse {
@@ -15,6 +16,7 @@ interface TranslatedChannelResponse {
     name?: string;
     description?: string;
     status: 'completed' | 'pending';
+    message?: string;
   };
 }
 
@@ -78,6 +80,7 @@ export const getChannelById = async (
   response.translation = {
     languageCode,
     status: 'pending',
+    message: getPendingMessage(languageCode),
   };
 
   return response;

--- a/src/services/packageService.ts
+++ b/src/services/packageService.ts
@@ -3,6 +3,7 @@ import { Translation } from '../models/Translation';
 import { NotFoundError } from '../utils/errors';
 import { translationQueue } from '../queues/translationQueue';
 import { redisClient } from '../config/reddis/reddisClient';
+import { getPendingMessage } from '../utils/localization';
 
 // Defines the shape of the API response for a package.
 interface TranslatedPackageResponse {
@@ -18,6 +19,7 @@ interface TranslatedPackageResponse {
     languageCode: string;
     name?: string;
     description?: string;
+    message?: string;
   };
 }
 
@@ -93,6 +95,7 @@ export const getPackageById = async (
   response.translation = {
     languageCode,
     status: 'pending',
+    message: getPendingMessage(languageCode),
   };
 
   return response;

--- a/src/utils/localization.ts
+++ b/src/utils/localization.ts
@@ -1,0 +1,14 @@
+const pendingMessages: {[key: string] :string} = {
+    es: 'El contenido se está traduciendo a español. Por favor, inténtelo de nuevo en unos segundos.',
+    fr: "Le contenu est en cours de traduction en français. Veuillez réessayer dans quelques instants.",
+    de: 'Inhalte werden ins Deutsche übersetzt. Bitte versuchen Sie es in Kürken wieder.',
+    it: 'Il contenuto è in fase di traduzione in italiano. Riprova tra qualche istante.',
+    jp: 'コンテンツは日本語に翻訳中です。数秒後にもう一度お試しください。',
+    // Default message for any other language
+    default:
+      'Content is being translated. Please try again in a few moments.',
+  };
+
+  export const getPendingMessage = (lang: string): string => {
+    return pendingMessages[lang.toLowerCase()] || pendingMessages.default;
+  }

--- a/src/utils/translator.ts
+++ b/src/utils/translator.ts
@@ -1,0 +1,66 @@
+/**
+ * Fetches a translation from the DeepL API using the native fetch.
+ * Includes a timeout to prevent the process from hanging.
+ * @param text - The text to translate.
+ * @param lang - The target language code.
+ * @returns A promise that resolves to the translated text.
+ * @throws An error if the API call fails or times out.
+ */
+export const fetchTranslation = async (text: string, lang: string): Promise<string> => {
+    const apiUrl = 'https://api-free.deepl.com/v2/translate';
+    const apiKey = process.env.DEEPL_API_KEY;
+  
+    if (!apiKey) {
+      console.error('🔴 ERROR: DeepL API key is not configured.');
+      // If the key is missing, we throw an error to fail the job immediately.
+      throw new Error('DeepL API key is not configured.');
+    }
+  
+    // AbortController is the standard way to implement timeouts with fetch.
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000); // 10-second timeout
+  
+    try {
+      const response = await fetch(apiUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `DeepL-Auth-Key ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          text: [text],
+          target_lang: lang,
+        }),
+        signal: controller.signal, // Pass the abort signal to fetch
+      });
+  
+      // Clear the timeout if the fetch completes in time
+      clearTimeout(timeoutId);
+  
+      if (!response.ok) {
+        // If the API returns an error (like 400 for an invalid language),
+        // we can get more details from the response body.
+        const errorData = await response.json();
+        throw new Error(
+          `DeepL API Error: ${response.status} - ${errorData.message || response.statusText}`
+        );
+      }
+  
+      const data = await response.json();
+      return data.translations[0].text;
+    } catch (error: any) {
+      // Clear the timeout in case of an error as well
+      clearTimeout(timeoutId);
+  
+      // Differentiate between a timeout error and other errors
+      if (error.name === 'AbortError') {
+        throw new Error('DeepL API Error: Request timed out after 10 seconds.');
+      }
+      // Re-throw the original error to be caught by the worker.
+      throw error;
+    }finally {
+      clearTimeout(timeoutId);
+    }
+  };
+  
+  


### PR DESCRIPTION
- Replaces the mock translation function with a real API call to DeepL using native fetch.
- Implements a request timeout and proper error handling for external API calls to prevent hanging jobs.
- The worker now correctly marks jobs as failed when the translation API returns an error, ensuring data integrity.
- Centralizes the translation logic into a reusable translator utility.