### PR TITLE
feat-auth) Implement password reset flow

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -160,3 +160,22 @@ export const getMe = (req: Request, res: Response) => {
     },
   });
 };
+
+export const forgotPassword = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+      await authService.forgotPassword(req.body.email);
+      res.status(200).json({ message: 'A password reset link has been sent.' });
+  } catch (error) {
+      next(error);
+  }
+};
+
+export const resetPassword = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+      const { token, password } = req.body;
+      await authService.resetPassword(token, password);
+      res.status(200).json({ message: 'Password has been reset successfully.' });
+  } catch (error) {
+      next(error);
+  }
+};

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -1,8 +1,8 @@
 import Router from "express";
-import { register, login, getMe, logout, refreshToken, verifyEmail, googleCallback } from "../controllers/authController";
+import { register, login, getMe, logout, refreshToken, verifyEmail, googleCallback, forgotPassword, resetPassword } from "../controllers/authController";
 import { protect } from "../middlewares/authMiddleware";
 import { validateRequest } from "../middlewares/validationMiddleware";
-import { registerSchema, loginSchema } from "../schemas/authSchemas";
+import { registerSchema, loginSchema, forgotPasswordSchema, resetPasswordSchema } from "../schemas/authSchemas";
 import passport from "passport";
 
 /**
@@ -41,14 +41,19 @@ router.post('/logout', logout);
  */
 router.post('/refresh-token', refreshToken);
 
-
-
+/**
+ * GET /auth/verify-email
+ * Verify user email
+ */
 router.get('/verify-email', verifyEmail); 
 
 // Google OAuth Routes
 router.get('/google', passport.authenticate('google', { scope: ['profile', 'email'], session: false }));
 router.get('/google/callback', passport.authenticate('google', { failureRedirect: '/login', session: false }), googleCallback);
 
+// Password Reset Routes
+router.post('/forgot-password', validateRequest(forgotPasswordSchema), forgotPassword);
+router.post('/reset-password', validateRequest(resetPasswordSchema), resetPassword);
 
 
 

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -44,3 +44,17 @@ export const sendVerificationEmail = async (userEmail: string, token: string) =>
 
     await sendEmail({ to: userEmail, subject, html });
 }
+
+export const sendPasswordResetEmail = async (userEmail: string, token: string) => {
+  const resetLink = `http://localhost:3001/reset-password?token=${token}`;
+  const subject = 'Your Password Reset Request for OmniverseTV';
+  const html = `
+      <h1>Password Reset Request</h1>
+      <p>You requested a password reset. Please click the link below to set a new password:</p>
+      <a href="${resetLink}">Reset My Password</a>
+      <p>This link will expire in 10 minutes.</p>
+      <p>If you did not request a password reset, please ignore this email.</p>
+  `;
+
+  await sendEmail({ to: userEmail, subject, html });
+}


### PR DESCRIPTION
Implements a secure, two-step password reset process for users registered with a local account (email and password).

- Adds a `POST /api/v1/auth/forgot-password` endpoint that:
  - Validates a user's email.
  - Generates a secure, short-lived (10-minute) reset token.
  - Sends an email containing the reset link via the email service.
  - This flow is restricted to users with the 'local' auth provider.

- Adds a `POST /api/v1/auth/reset-password` endpoint that:
  - Validates the token from the email and the new password.
  - Updates the user's password hash if the token is valid and has not expired.
  - The reset token fields are cleared from the database after a successful reset to prevent reuse.

- The `User` model has been updated with `password_reset_token` and `password_reset_token_expires` fields to support this flow.